### PR TITLE
change to use download.ros.org instead of pr.willowgarage.com

### DIFF
--- a/prosilica_gige_sdk/Makefile
+++ b/prosilica_gige_sdk/Makefile
@@ -1,7 +1,7 @@
 default: installed all viewer
 
 TARBALL = build/Prosilica\ GigE\ SDK\ 1.20\ Linux.tgz
-TARBALL_URL = http://pr.willowgarage.com/downloads/Prosilica%20GigE%20SDK%201.20%20Linux.tgz
+TARBALL_URL = http://download.ros.org/downloads/Prosilica%20GigE%20SDK%201.20%20Linux.tgz
 SOURCE_DIR = build/Prosilica_GigE_SDK
 INITIAL_DIR = build/Prosilica\ GigE\ SDK
 ARCH = $(shell uname -m)


### PR DESCRIPTION
pr.willowgarage.com is now gone.
