### PR TITLE
Remove driver_base dependency as this package is deprecated

### DIFF
--- a/prosilica_camera/CMakeLists.txt
+++ b/prosilica_camera/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(catkin REQUIRED COMPONENTS
    diagnostic_updater
    image_transport
    self_test 
-   driver_base
    rosconsole
    dynamic_reconfigure 
    camera_calibration_parsers 

--- a/prosilica_camera/cfg/ProsilicaCamera.cfg
+++ b/prosilica_camera/cfg/ProsilicaCamera.cfg
@@ -2,7 +2,7 @@
 
 PACKAGE='prosilica_camera'
 
-from driver_base.msg import SensorLevels
+from dynamic_reconfigure.msg import SensorLevels
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()

--- a/prosilica_camera/package.xml
+++ b/prosilica_camera/package.xml
@@ -22,7 +22,6 @@
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>self_test</build_depend>
-  <build_depend>driver_base</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>camera_calibration_parsers</build_depend>
   <build_depend>polled_camera</build_depend>
@@ -38,7 +37,6 @@
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>self_test</run_depend>
-  <run_depend>driver_base</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>camera_calibration_parsers</run_depend>
   <run_depend>polled_camera</run_depend>

--- a/prosilica_camera/src/nodes/prosilica_nodelet.cpp
+++ b/prosilica_camera/src/nodes/prosilica_nodelet.cpp
@@ -36,7 +36,7 @@
 #include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>
 #include <dynamic_reconfigure/server.h>
-#include <driver_base/SensorLevels.h>
+#include <dynamic_reconfigure/SensorLevels.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/publisher.h>
 #include <camera_calibration_parsers/parse_ini.h>
@@ -515,7 +515,7 @@ private:
         last_config_.height   = req.roi.height;
         last_config_.width    = req.roi.width;
 
-        reconfigureCallback(last_config_, driver_base::SensorLevels::RECONFIGURE_RUNNING);
+        reconfigureCallback(last_config_, dynamic_reconfigure::SensorLevels::RECONFIGURE_RUNNING);
 
         try
         {
@@ -690,7 +690,7 @@ private:
     {
         NODELET_DEBUG("Reconfigure request received");
 
-        if (level >= (uint32_t)driver_base::SensorLevels::RECONFIGURE_STOP)
+        if (level >= (uint32_t)dynamic_reconfigure::SensorLevels::RECONFIGURE_STOP)
             stop();
 
         //! Trigger mode
@@ -865,7 +865,7 @@ private:
 
         //! If exception thrown due to bad settings, it will fail to start camera
         //! Reload last good config
-        if (level >= (uint32_t)driver_base::SensorLevels::RECONFIGURE_STOP)
+        if (level >= (uint32_t)dynamic_reconfigure::SensorLevels::RECONFIGURE_STOP)
         {
             try
             {


### PR DESCRIPTION
Only the SensorLevels message is needed from this package, which is now
provided by dynamic_reconfigure in Kinetic.