### PR TITLE
updated settings for noetic compile

### DIFF
--- a/prosilica_camera/CMakeLists.txt
+++ b/prosilica_camera/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(prosilica_camera)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(catkin REQUIRED COMPONENTS 
    prosilica_gige_sdk
@@ -33,6 +34,7 @@ target_link_libraries(prosilica ${catkin_LIBRARIES})
 
 add_library(prosilica_nodelet src/nodes/prosilica_nodelet.cpp)
 target_link_libraries(prosilica_nodelet prosilica ${catkin_LIBRARIES})
+add_dependencies(prosilica_nodelet ${PROJECT_NAME}_gencfg)
 class_loader_hide_library_symbols(prosilica_nodelet)
 
 add_executable(prosilica_node src/nodes/prosilica_node.cpp)

--- a/prosilica_camera/src/nodes/prosilica_nodelet.cpp
+++ b/prosilica_camera/src/nodes/prosilica_nodelet.cpp
@@ -49,6 +49,8 @@
 #include <sensor_msgs/SetCameraInfo.h>
 
 #include <boost/thread.hpp>
+#include <boost/format.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <prosilica_camera/ProsilicaCameraConfig.h>
 #include "prosilica/prosilica.h"
@@ -307,7 +309,8 @@ private:
 
             }
             updater.update();
-            boost::this_thread::sleep(boost::posix_time::seconds(open_camera_retry_period_));
+            boost::posix_time::millisec itime = boost::posix_time::millisec( (int) (open_camera_retry_period_ * 1000));
+            boost::this_thread::sleep(itime);
         }
         loadIntrinsics();
         start();


### PR DESCRIPTION
passes pre-release testing under focal/noetic:

generate_prerelease_script.py   https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml   noetic default ubuntu focal amd64   --custom-repo     prosilica_camera__custom-2:git:https://github.com/PR2-prime/prosilica_driver.git:noetic-devel     prosilica_gige_sdk__custom-3:git:https://github.com/ros-drivers/prosilica_gige_sdk.git:hydro-devel   --level 1   --output-dir ./^C
