### PR TITLE
fix install location of plugin manifest xml

### DIFF
--- a/prosilica_camera/CMakeLists.txt
+++ b/prosilica_camera/CMakeLists.txt
@@ -75,5 +75,8 @@ install(TARGETS prosilica prosilica_nodelet
 install(DIRECTORY launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(FILES prosilica.launch streaming.launch plugins/nodelet_plugins.xml
+install(DIRECTORY plugins 
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(FILES prosilica.launch streaming.launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
This PR fixes install location of plugin xml.
Current cmake means that plugin xml will be installed to `share` directory, which cause plugin load error.

```
/opt/ros/noetic/share/prosilica_camera$ ls
cmake  launch  nodelet_plugins.xml  package.xml  prosilica.launch  streaming.launch
/opt/ros/noetic/share/prosilica_camera$ ls nodelet_plugins.xml 
nodelet_plugins.xml
```

Plugin manifest xml should be `share/plugins`.
https://github.com/ros-drivers/prosilica_driver/blob/3991df761ce0400b9993166c09a2529ef684cdc1/prosilica_camera/package.xml#L47

I change to install the manifest xml to correct path in cmake.
